### PR TITLE
Update coveralls image badge to square

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This plugin's code is heavily inspired on the [tkellen](https://github.com/tkell
 
 MIT
 
-[coveralls-image]: https://coveralls.io/repos/github/seegno/bookshelf-cascade-delete/badge.svg?branch=master
+[coveralls-image]: https://img.shields.io/coveralls/seegno/bookshelf-cascade-delete/master.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/github/seegno/bookshelf-cascade-delete?branch=master
 [npm-image]: https://img.shields.io/npm/v/bookshelf-cascade-delete.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/bookshelf-cascade-delete


### PR DESCRIPTION
This PR updates the coveralls image badge to square instead of current badge that have rounded corners.

Before:
<img width="303" alt="screen shot 2016-04-22 at 20 28 54" src="https://cloud.githubusercontent.com/assets/1175149/14752730/e73e72c2-08c8-11e6-8370-2e8620c91bde.png">

After:
<img width="300" alt="screen shot 2016-04-22 at 20 29 59" src="https://cloud.githubusercontent.com/assets/1175149/14752748/0457a9a0-08c9-11e6-82ff-a1f67d8624fe.png">
