### PR TITLE
Add babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test": "mocha $npm_package_options_mocha"
   },
   "dependencies": {
+    "babel-runtime": "^6.6.1",
     "bluebird": "^3.3.5",
     "lodash": "^4.11.1"
   },
@@ -48,7 +49,6 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
     "babel-register": "^6.7.2",
-    "babel-runtime": "^6.6.1",
     "bookshelf": "^0.9.4",
     "coveralls": "^2.11.9",
     "eslint": "^2.8.0",


### PR DESCRIPTION
This PR adds **babel-runtime** to dependencies.

Closes #3 
