### PR TITLE
Fix destroying models with non default id attribute

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { clearTables, dropTables, fixtures, recreateTables } from './utils';
 import Bookshelf from 'bookshelf';
 import cascadeDelete from '../src';
 import knex from 'knex';
@@ -11,6 +10,7 @@ import mysqlKnexfile from './mysql.knexfile';
 import postgresKnexfile from './postgres.knexfile';
 import should from 'should';
 import sinon from 'sinon';
+import { clearTables, dropTables, fixtures, recreateTables } from './utils';
 
 /**
  * Test `bookshelf-cascade-delete` plugin.
@@ -38,9 +38,9 @@ describe('bookshelf-cascade-delete', () => {
     });
 
     it('should throw an error if model has no registered dependents', async () => {
-      const author = await repository.Model.extend({ tableName: 'Author' }).forge().save();
+      const author = await repository.Model.extend({ idAttribute: 'author_id', tableName: 'Author' }).forge().save();
 
-      await Account.forge().save({ authorId: author.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
 
       try {
         await author.destroy();
@@ -54,7 +54,7 @@ describe('bookshelf-cascade-delete', () => {
     it('should throw an error if model has dependents and `cascadeDelete` option is given as `false`', async () => {
       const author = await Author.forge().save();
 
-      await Account.forge().save({ authorId: author.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
 
       try {
         await author.destroy({ cascadeDelete: false });
@@ -67,10 +67,10 @@ describe('bookshelf-cascade-delete', () => {
 
     it('should not delete model and its dependents if an error is thrown on destroy', async () => {
       const author = await Author.forge().save();
-      const post = await Post.forge().save({ authorId: author.get('id') });
+      const post = await Post.forge().save({ authorId: author.get('author_id') });
 
-      await Account.forge().save({ authorId: author.get('id') });
-      await Comment.forge().save({ postId: post.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
+      await Comment.forge().save({ postId: post.get('post_id') });
 
       sinon.stub(Model, 'destroy').throws(new Error('foobar'));
 
@@ -118,12 +118,12 @@ describe('bookshelf-cascade-delete', () => {
 
     it('should delete model and all its dependents', async () => {
       const author = await Author.forge().save();
-      const post1 = await Post.forge().save({ authorId: author.get('id') });
-      const post2 = await Post.forge().save({ authorId: author.get('id') });
+      const post1 = await Post.forge().save({ authorId: author.get('author_id') });
+      const post2 = await Post.forge().save({ authorId: author.get('author_id') });
 
-      await Account.forge().save({ authorId: author.get('id') });
-      await Comment.forge().save({ postId: post1.get('id') });
-      await Comment.forge().save({ postId: post2.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
+      await Comment.forge().save({ postId: post1.get('post_id') });
+      await Comment.forge().save({ postId: post2.get('post_id') });
 
       await author.destroy();
 
@@ -141,13 +141,13 @@ describe('bookshelf-cascade-delete', () => {
     it('should not delete models which are not dependent', async () => {
       const author1 = await Author.forge().save();
       const author2 = await Author.forge().save();
-      const post1 = await Post.forge().save({ authorId: author1.get('id') });
-      const post2 = await Post.forge().save({ authorId: author2.get('id') });
+      const post1 = await Post.forge().save({ authorId: author1.get('author_id') });
+      const post2 = await Post.forge().save({ authorId: author2.get('author_id') });
 
-      await Account.forge().save({ authorId: author1.get('id') });
-      await Account.forge().save({ authorId: author2.get('id') });
-      await Comment.forge().save({ postId: post1.get('id') });
-      await Comment.forge().save({ postId: post2.get('id') });
+      await Account.forge().save({ authorId: author1.get('author_id') });
+      await Account.forge().save({ authorId: author2.get('author_id') });
+      await Comment.forge().save({ postId: post1.get('post_id') });
+      await Comment.forge().save({ postId: post2.get('post_id') });
 
       await author1.destroy();
 
@@ -197,9 +197,9 @@ describe('bookshelf-cascade-delete', () => {
     });
 
     it('should throw an error if model has no registered dependents', async () => {
-      const author = await repository.Model.extend({ tableName: 'Author' }).forge().save();
+      const author = await repository.Model.extend({ idAttribute: 'author_id', tableName: 'Author' }).forge().save();
 
-      await Account.forge().save({ authorId: author.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
 
       try {
         await author.destroy();
@@ -213,7 +213,7 @@ describe('bookshelf-cascade-delete', () => {
     it('should throw an error if model has dependents and `cascadeDelete` option is given as `false`', async () => {
       const author = await Author.forge().save();
 
-      await Account.forge().save({ authorId: author.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
 
       try {
         await author.destroy({ cascadeDelete: false });
@@ -226,10 +226,10 @@ describe('bookshelf-cascade-delete', () => {
 
     it('should not delete model and its dependents if an error is thrown on destroy', async () => {
       const author = await Author.forge().save();
-      const post = await Post.forge().save({ authorId: author.get('id') });
+      const post = await Post.forge().save({ authorId: author.get('author_id') });
 
-      await Account.forge().save({ authorId: author.get('id') });
-      await Comment.forge().save({ postId: post.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
+      await Comment.forge().save({ postId: post.get('post_id') });
 
       sinon.stub(Model, 'destroy').throws(new Error('foobar'));
 
@@ -277,12 +277,12 @@ describe('bookshelf-cascade-delete', () => {
 
     it('should delete model and all its dependents', async () => {
       const author = await Author.forge().save();
-      const post1 = await Post.forge().save({ authorId: author.get('id') });
-      const post2 = await Post.forge().save({ authorId: author.get('id') });
+      const post1 = await Post.forge().save({ authorId: author.get('author_id') });
+      const post2 = await Post.forge().save({ authorId: author.get('author_id') });
 
-      await Account.forge().save({ authorId: author.get('id') });
-      await Comment.forge().save({ postId: post1.get('id') });
-      await Comment.forge().save({ postId: post2.get('id') });
+      await Account.forge().save({ authorId: author.get('author_id') });
+      await Comment.forge().save({ postId: post1.get('post_id') });
+      await Comment.forge().save({ postId: post2.get('post_id') });
 
       await author.destroy();
 
@@ -300,13 +300,13 @@ describe('bookshelf-cascade-delete', () => {
     it('should not delete models which are not dependent', async () => {
       const author1 = await Author.forge().save();
       const author2 = await Author.forge().save();
-      const post1 = await Post.forge().save({ authorId: author1.get('id') });
-      const post2 = await Post.forge().save({ authorId: author2.get('id') });
+      const post1 = await Post.forge().save({ authorId: author1.get('author_id') });
+      const post2 = await Post.forge().save({ authorId: author2.get('author_id') });
 
-      await Account.forge().save({ authorId: author1.get('id') });
-      await Account.forge().save({ authorId: author2.get('id') });
-      await Comment.forge().save({ postId: post1.get('id') });
-      await Comment.forge().save({ postId: post2.get('id') });
+      await Account.forge().save({ authorId: author1.get('author_id') });
+      await Account.forge().save({ authorId: author2.get('author_id') });
+      await Comment.forge().save({ postId: post1.get('post_id') });
+      await Comment.forge().save({ postId: post2.get('post_id') });
 
       await author1.destroy();
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -10,19 +10,19 @@ export function recreateTables(repository) {
     .dropTableIfExists('Post')
     .dropTableIfExists('Author')
     .createTable('Author', table => {
-      table.increments('id').primary();
+      table.increments('author_id').primary();
     })
     .createTable('Account', table => {
-      table.increments('id').primary();
-      table.integer('authorId').unsigned().references('Author.id');
+      table.increments('account_id').primary();
+      table.integer('authorId').unsigned().references('Author.author_id');
     })
     .createTable('Post', table => {
-      table.increments('id').primary();
-      table.integer('authorId').unsigned().references('Author.id');
+      table.increments('post_id').primary();
+      table.integer('authorId').unsigned().references('Author.author_id');
     })
     .createTable('Comment', table => {
-      table.increments('id').primary();
-      table.integer('postId').unsigned().references('Post.id');
+      table.increments('comment_id').primary();
+      table.integer('postId').unsigned().references('Post.post_id');
     });
 }
 
@@ -54,13 +54,21 @@ export function dropTables(repository) {
  */
 
 export function fixtures(repository) {
-  const Account = repository.Model.extend({ tableName: 'Account' });
-  const Comment = repository.Model.extend({ tableName: 'Comment' });
+  const Account = repository.Model.extend({
+    idAttribute: 'account_id',
+    tableName: 'Account'
+  });
+
+  const Comment = repository.Model.extend({
+    idAttribute: 'comment_id',
+    tableName: 'Comment'
+  });
 
   const Post = repository.Model.extend({
     comments() {
       return this.hasMany(Comment, 'postId');
     },
+    idAttribute: 'post_id',
     tableName: 'Post'
   }, {
     dependents: ['comments']
@@ -70,6 +78,7 @@ export function fixtures(repository) {
     account() {
       return this.hasOne(Account, 'authorId');
     },
+    idAttribute: 'author_id',
     posts() {
       return this.hasMany(Post, 'authorId');
     },


### PR DESCRIPTION
This PR replaces the default `id` attribute for the use of model's `idAttribute`. 

Closes #11 
