### PR TITLE
Fix cascade delete with queried models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default Bookshelf => {
 
   Bookshelf.Model = Bookshelf.Model.extend({
     cascadeDelete(transaction, options) {
-      return mapSeries(this.constructor.recursiveDeletes(this.get(this.idAttribute), options), query => query(transaction))
+      return mapSeries(this.constructor.recursiveDeletes(this.get(this.idAttribute) || this._knex.column(this.idAttribute), options), query => query(transaction))
         .then(() => Model.destroy.call(this, {
           ...options,
           transacting: transaction

--- a/test/mysql/index.js
+++ b/test/mysql/index.js
@@ -142,6 +142,34 @@ describe('with MySQL client', () => {
     tagPosts.length.should.equal(0);
   });
 
+  it('should delete queried model and all its dependents', async () => {
+    const author = await Author.forge().save({ name: 'foobar' });
+    const post1 = await Post.forge().save({ authorId: author.get('author_id') });
+    const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const tag1 = await Tag.forge().save();
+    const tag2 = await Tag.forge().save();
+
+    await Account.forge().save({ authorId: author.get('author_id') });
+    await Comment.forge().save({ postId: post1.get('post_id') });
+    await Comment.forge().save({ postId: post2.get('post_id') });
+    await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
+    await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
+
+    await Author.forge().where({ name: 'foobar' }).destroy();
+
+    const accounts = await Account.fetchAll();
+    const authors = await Author.fetchAll();
+    const comments = await Comment.fetchAll();
+    const posts = await Post.fetchAll();
+    const tagPosts = await TagPost.fetchAll();
+
+    accounts.length.should.equal(0);
+    authors.length.should.equal(0);
+    comments.length.should.equal(0);
+    posts.length.should.equal(0);
+    tagPosts.length.should.equal(0);
+  });
+
   it('should not delete models which are not dependent', async () => {
     const author1 = await Author.forge().save();
     const author2 = await Author.forge().save();

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -142,6 +142,34 @@ describe('with PostgreSQL client', () => {
     tagPosts.length.should.equal(0);
   });
 
+  it('should delete queried model and all its dependents', async () => {
+    const author = await Author.forge().save({ name: 'foobar' });
+    const post1 = await Post.forge().save({ authorId: author.get('author_id') });
+    const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const tag1 = await Tag.forge().save();
+    const tag2 = await Tag.forge().save();
+
+    await Account.forge().save({ authorId: author.get('author_id') });
+    await Comment.forge().save({ postId: post1.get('post_id') });
+    await Comment.forge().save({ postId: post2.get('post_id') });
+    await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
+    await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
+
+    await Author.forge().where({ name: 'foobar' }).destroy();
+
+    const accounts = await Account.fetchAll();
+    const authors = await Author.fetchAll();
+    const comments = await Comment.fetchAll();
+    const posts = await Post.fetchAll();
+    const tagPosts = await TagPost.fetchAll();
+
+    accounts.length.should.equal(0);
+    authors.length.should.equal(0);
+    comments.length.should.equal(0);
+    posts.length.should.equal(0);
+    tagPosts.length.should.equal(0);
+  });
+
   it('should not delete models which are not dependent', async () => {
     const author1 = await Author.forge().save();
     const author2 = await Author.forge().save();

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -13,6 +13,7 @@ export function recreateTables(repository) {
     .dropTableIfExists('Author')
     .createTable('Author', table => {
       table.increments('author_id').primary();
+      table.string('name');
     })
     .createTable('Account', table => {
       table.increments('account_id').primary();


### PR DESCRIPTION
This PR adds support for `destroy` on queried models.

Closes #14 
