### PR TITLE
Fix cascade delete on third level dependents

### DIFF
--- a/test/mysql/index.js
+++ b/test/mysql/index.js
@@ -21,7 +21,7 @@ describe('with MySQL client', () => {
 
   repository.plugin(cascadeDelete);
 
-  const { Account, Author, Comment, Post, Tag, TagPost } = fixtures(repository);
+  const { Account, Author, Comment, Commenter, Post, Tag, TagPost } = fixtures(repository);
 
   before(async () => {
     await recreateTables(repository);
@@ -66,9 +66,10 @@ describe('with MySQL client', () => {
   it('should not delete model and its dependents if an error is thrown on destroy', async () => {
     const author = await Author.forge().save();
     const post = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment = await Comment.forge().save({ postId: post.get('post_id') });
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post.get('post_id') });
+    await Commenter.forge().save({ commentId: comment.get('comment_id') });
 
     sinon.stub(Model, 'destroy').throws(new Error('foobar'));
 
@@ -82,11 +83,13 @@ describe('with MySQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
+    commenters.length.should.equal(1);
     comments.length.should.equal(1);
     posts.length.should.equal(1);
 
@@ -118,12 +121,14 @@ describe('with MySQL client', () => {
     const author = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -131,12 +136,14 @@ describe('with MySQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
+    commenters.length.should.equal(0);
     comments.length.should.equal(0);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
@@ -146,12 +153,14 @@ describe('with MySQL client', () => {
     const author = await Author.forge().save({ name: 'foobar' });
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -159,12 +168,14 @@ describe('with MySQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
+    commenters.length.should.equal(0);
     comments.length.should.equal(0);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
@@ -175,13 +186,15 @@ describe('with MySQL client', () => {
     const author2 = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author1.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author2.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author1.get('author_id') });
     await Account.forge().save({ authorId: author2.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -189,12 +202,14 @@ describe('with MySQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
+    commenters.length.should.equal(1);
     comments.length.should.equal(1);
     posts.length.should.equal(1);
     tagPosts.length.should.equal(1);

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -21,7 +21,7 @@ describe('with PostgreSQL client', () => {
 
   repository.plugin(cascadeDelete);
 
-  const { Account, Author, Comment, Post, Tag, TagPost } = fixtures(repository);
+  const { Account, Author, Comment, Commenter, Post, Tag, TagPost } = fixtures(repository);
 
   before(async () => {
     await recreateTables(repository);
@@ -66,9 +66,10 @@ describe('with PostgreSQL client', () => {
   it('should not delete model and its dependents if an error is thrown on destroy', async () => {
     const author = await Author.forge().save();
     const post = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment = await Comment.forge().save({ postId: post.get('post_id') });
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post.get('post_id') });
+    await Commenter.forge().save({ commentId: comment.get('comment_id') });
 
     sinon.stub(Model, 'destroy').throws(new Error('foobar'));
 
@@ -82,11 +83,13 @@ describe('with PostgreSQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
+    commenters.length.should.equal(1);
     comments.length.should.equal(1);
     posts.length.should.equal(1);
 
@@ -118,12 +121,14 @@ describe('with PostgreSQL client', () => {
     const author = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -131,12 +136,14 @@ describe('with PostgreSQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
+    commenters.length.should.equal(0);
     comments.length.should.equal(0);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
@@ -146,12 +153,14 @@ describe('with PostgreSQL client', () => {
     const author = await Author.forge().save({ name: 'foobar' });
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -159,12 +168,14 @@ describe('with PostgreSQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
+    commenters.length.should.equal(0);
     comments.length.should.equal(0);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
@@ -175,13 +186,15 @@ describe('with PostgreSQL client', () => {
     const author2 = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author1.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author2.get('author_id') });
+    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author1.get('author_id') });
     await Account.forge().save({ authorId: author2.get('author_id') });
-    await Comment.forge().save({ postId: post1.get('post_id') });
-    await Comment.forge().save({ postId: post2.get('post_id') });
+    await Commenter.forge().save({ commentId: comment1.get('comment_id') });
+    await Commenter.forge().save({ commentId: comment2.get('comment_id') });
     await TagPost.forge().save({ postId: post1.get('post_id'), tagId: tag1.get('tag_id') });
     await TagPost.forge().save({ postId: post2.get('post_id'), tagId: tag2.get('tag_id') });
 
@@ -189,12 +202,14 @@ describe('with PostgreSQL client', () => {
 
     const accounts = await Account.fetchAll();
     const authors = await Author.fetchAll();
+    const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
+    commenters.length.should.equal(1);
     comments.length.should.equal(1);
     posts.length.should.equal(1);
     tagPosts.length.should.equal(1);

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -33,6 +33,10 @@ export function recreateTables(repository) {
     .createTable('Comment', table => {
       table.increments('comment_id').primary();
       table.integer('postId').unsigned().references('Post.post_id');
+    })
+    .createTable('Commenter', table => {
+      table.increments('commenter_id').primary();
+      table.integer('commentId').unsigned().references('Comment.comment_id');
     });
 }
 
@@ -42,6 +46,7 @@ export function recreateTables(repository) {
 
 export async function clearTables(repository) {
   await repository.knex('Account').del();
+  await repository.knex('Commenter').del();
   await repository.knex('Comment').del();
   await repository.knex('TagPost').del();
   await repository.knex('Post').del();
@@ -57,6 +62,7 @@ export function dropTables(repository) {
   return repository.knex.schema
     .dropTable('TagPost')
     .dropTable('Account')
+    .dropTable('Commenter')
     .dropTable('Comment')
     .dropTable('Post')
     .dropTable('Tag')
@@ -73,9 +79,19 @@ export function fixtures(repository) {
     tableName: 'Account'
   });
 
+  const Commenter = repository.Model.extend({
+    idAttribute: 'commenter_id',
+    tableName: 'Commenter'
+  });
+
   const Comment = repository.Model.extend({
+    commenter() {
+      return this.hasOne(Commenter, 'commentId');
+    },
     idAttribute: 'comment_id',
     tableName: 'Comment'
+  }, {
+    dependents: ['commenter']
   });
 
   const Tag = repository.Model.extend({
@@ -114,5 +130,5 @@ export function fixtures(repository) {
     dependents: ['account', 'posts']
   });
 
-  return { Account, Author, Comment, Post, Tag, TagPost };
+  return { Account, Author, Comment, Commenter, Post, Tag, TagPost };
 }


### PR DESCRIPTION
This PR fixes the order of the queries returned by `recursiveDeletes` when there is up to three levels of dependents, adding the `Commenter` entity to test fixtures in order to emulate this scenario.
