### PR TITLE
Add babel-plugin-add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-runtime"]
+  "plugins": ["add-module-exports", "transform-runtime"]
 }

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Require and register the `bookshelf-cascade-delete` plugin:
 var bookshelf = require('bookshelf')(knex);
 var cascadeDelete = require('bookshelf-cascade-delete');
 
-// You need to access the `default` property since the plugin is transpiled from es6 modules syntax.
-bookshelf.plugin(cascadeDelete.default);
+bookshelf.plugin(cascadeDelete);
 ```
 
 Define which relations depend on your model when it's destroyed with the `dependents` prototype property:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",


### PR DESCRIPTION
This PR adds the `babel-plugin-add-module-exports` as Babel 6 doesn't export default `module.exports` any more.
