### PR TITLE
Update test coverage scripts to use nyc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  },
   "presets": ["es2015", "stage-2"],
   "plugins": ["add-module-exports", "transform-runtime"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /test/coverage
 /test/mysql/knexfile.js
 /test/postgres/knexfile.js
+/.nyc_output

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "delete"
   ],
   "options": {
-    "isparta": "--dir test/coverage",
-    "mocha": "-t 10000 -b --compilers js:babel-register test/index.js"
+    "mocha": "-t 10000 -b --compilers js:babel-register test/index.js",
+    "nyc": "--reporter=lcov --reporter=html --reporter=text-summary --report-dir test/coverage"
   },
   "scripts": {
     "changelog": "github_changelog_generator --bug-labels --enhancement-labels --future-release=$npm_config_release --header-label='# Changelog'",
-    "cover": "babel-node node_modules/.bin/isparta cover $npm_package_options_isparta _mocha -- $npm_package_options_mocha",
+    "cover": "NODE_ENV=test nyc $npm_package_options_nyc mocha $npm_package_options_mocha",
     "coveralls": "npm run cover && cat ./test/coverage/lcov.info | coveralls",
     "lint": "git diff --cached --name-only --diff-filter=ACMRTUXB | grep -E '\\.(js)(\\..+)?$' | xargs eslint",
     "release": "npm run changelog && npm run version && npm run transpile && git add -A && git commit -n -m \"Release $npm_config_release\"",
@@ -48,6 +48,7 @@
     "babel-cli": "^6.7.5",
     "babel-eslint": "^6.0.2",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-istanbul": "^2.0.1",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
@@ -58,10 +59,10 @@
     "eslint-config-seegno": "^4.0.0",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-sort-class-members": "^1.0.1",
-    "isparta": "^4.0.0",
     "knex": "^0.10.0",
     "mocha": "^2.4.5",
     "mysql": "^2.10.2",
+    "nyc": "^8.3.1",
     "pg": "^4.5.3",
     "pre-commit": "^1.1.2",
     "should": "^8.3.1",
@@ -70,6 +71,10 @@
   "engines": {
     "iojs": ">= 1.0.0",
     "node": ">= 0.10"
+  },
+  "nyc": {
+    "instrument": false,
+    "sourceMap": false
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
This PR updates the `cover` and `coveralls` scripts to use **nyc** and **babel-plugin-istanbul** since **isparta** is no longer maintained.
