### PR TITLE
Fix deleting belongs to relations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,18 +20,24 @@ export default Bookshelf => {
    * Dependency map.
    */
 
-  function dependencyMap(skipDependents = false) {
-    if (skipDependents || !this.dependents) {
+  function dependencyMap() {
+    if (!this.dependents) {
       return;
     }
 
     return reduce(this.dependents, (result, dependent) => {
-      const { relatedData } = this.prototype[dependent]();
+      let relatedData;
+
+      try {
+        relatedData = this.prototype[dependent]().relatedData;
+      } catch (e) {
+        return result;
+      }
+
       const skipDependents = relatedData.type === 'belongsToMany';
 
       return [
         ...result, {
-          dependents: dependencyMap.call(relatedData.target, skipDependents),
           key: relatedData.key('foreignKey'),
           model: relatedData.target,
           skipDependents,

--- a/test/postgres/index.js
+++ b/test/postgres/index.js
@@ -3,13 +3,13 @@
  * Module dependencies.
  */
 
- import Bookshelf from 'bookshelf';
- import cascadeDelete from '../../src';
- import knex from 'knex';
- import knexfile from './knexfile';
- import should from 'should';
- import sinon from 'sinon';
- import { clearTables, dropTables, fixtures, recreateTables } from '../utils';
+import Bookshelf from 'bookshelf';
+import cascadeDelete from '../../src';
+import knex from 'knex';
+import knexfile from './knexfile';
+import should from 'should';
+import sinon from 'sinon';
+import { clearTables, dropTables, fixtures, recreateTables } from '../utils';
 
 /**
  * Test `bookshelf-cascade-delete` plugin with PostgreSQL client.
@@ -21,7 +21,7 @@ describe('with PostgreSQL client', () => {
 
   repository.plugin(cascadeDelete);
 
-  const { Account, Author, Comment, Commenter, Post, Tag, TagPost } = fixtures(repository);
+  const { Account, Author, Comment, CommentMetadata, Commenter, Post, Tag, TagPost } = fixtures(repository);
 
   before(async () => {
     await recreateTables(repository);
@@ -66,10 +66,13 @@ describe('with PostgreSQL client', () => {
   it('should not delete model and its dependents if an error is thrown on destroy', async () => {
     const author = await Author.forge().save();
     const post = await Post.forge().save({ authorId: author.get('author_id') });
-    const comment = await Comment.forge().save({ postId: post.get('post_id') });
+    const commentMetadata = await CommentMetadata.forge().save();
+    const comment = await Comment.forge().save({ metadata: commentMetadata.id, postId: post.get('post_id') });
+    const tag = await Tag.forge().save();
 
     await Account.forge().save({ authorId: author.get('author_id') });
     await Commenter.forge().save({ commentId: comment.get('comment_id') });
+    await TagPost.forge().save({ postId: post.get('post_id'), tagId: tag.get('tag_id') });
 
     sinon.stub(Model, 'destroy').throws(new Error('foobar'));
 
@@ -85,13 +88,19 @@ describe('with PostgreSQL client', () => {
     const authors = await Author.fetchAll();
     const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
+    const commentsMetadata = await CommentMetadata.fetchAll();
     const posts = await Post.fetchAll();
+    const tagPosts = await TagPost.fetchAll();
+    const tags = await Tag.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
     commenters.length.should.equal(1);
     comments.length.should.equal(1);
+    commentsMetadata.length.should.equal(1);
     posts.length.should.equal(1);
+    tagPosts.length.should.equal(1);
+    tags.length.should.equal(1);
 
     sinon.restore(Model);
   });
@@ -121,8 +130,10 @@ describe('with PostgreSQL client', () => {
     const author = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
-    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
-    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
+    const commentMetadata1 = await CommentMetadata.forge().save();
+    const commentMetadata2 = await CommentMetadata.forge().save();
+    const comment1 = await Comment.forge().save({ metadata: commentMetadata1.get('id'), postId: post1.get('post_id'), });
+    const comment2 = await Comment.forge().save({ metadata: commentMetadata2.get('id'), postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
@@ -138,23 +149,29 @@ describe('with PostgreSQL client', () => {
     const authors = await Author.fetchAll();
     const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
+    const commentsMetadata = await CommentMetadata.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
+    const tags = await Tag.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
     commenters.length.should.equal(0);
     comments.length.should.equal(0);
+    commentsMetadata.length.should.equal(2);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
+    tags.length.should.equal(2);
   });
 
   it('should delete queried model and all its dependents', async () => {
     const author = await Author.forge().save({ name: 'foobar' });
     const post1 = await Post.forge().save({ authorId: author.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author.get('author_id') });
-    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
-    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
+    const commentMetadata1 = await CommentMetadata.forge().save();
+    const commentMetadata2 = await CommentMetadata.forge().save();
+    const comment1 = await Comment.forge().save({ metadata: commentMetadata1.get('id'), postId: post1.get('post_id'), });
+    const comment2 = await Comment.forge().save({ metadata: commentMetadata2.get('id'), postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
@@ -170,15 +187,19 @@ describe('with PostgreSQL client', () => {
     const authors = await Author.fetchAll();
     const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
+    const commentsMetadata = await CommentMetadata.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
+    const tags = await Tag.fetchAll();
 
     accounts.length.should.equal(0);
     authors.length.should.equal(0);
     commenters.length.should.equal(0);
     comments.length.should.equal(0);
+    commentsMetadata.length.should.equal(2);
     posts.length.should.equal(0);
     tagPosts.length.should.equal(0);
+    tags.length.should.equal(2);
   });
 
   it('should not delete models which are not dependent', async () => {
@@ -186,8 +207,10 @@ describe('with PostgreSQL client', () => {
     const author2 = await Author.forge().save();
     const post1 = await Post.forge().save({ authorId: author1.get('author_id') });
     const post2 = await Post.forge().save({ authorId: author2.get('author_id') });
-    const comment1 = await Comment.forge().save({ postId: post1.get('post_id') });
-    const comment2 = await Comment.forge().save({ postId: post2.get('post_id') });
+    const commentMetadata1 = await CommentMetadata.forge().save();
+    const commentMetadata2 = await CommentMetadata.forge().save();
+    const comment1 = await Comment.forge().save({ metadata: commentMetadata1.id, postId: post1.get('post_id') });
+    const comment2 = await Comment.forge().save({ metadata: commentMetadata2.id, postId: post2.get('post_id') });
     const tag1 = await Tag.forge().save();
     const tag2 = await Tag.forge().save();
 
@@ -204,15 +227,19 @@ describe('with PostgreSQL client', () => {
     const authors = await Author.fetchAll();
     const commenters = await Commenter.fetchAll();
     const comments = await Comment.fetchAll();
+    const commentsMetadata = await CommentMetadata.fetchAll();
     const posts = await Post.fetchAll();
     const tagPosts = await TagPost.fetchAll();
+    const tags = await Tag.fetchAll();
 
     accounts.length.should.equal(1);
     authors.length.should.equal(1);
     commenters.length.should.equal(1);
     comments.length.should.equal(1);
+    commentsMetadata.length.should.equal(2);
     posts.length.should.equal(1);
     tagPosts.length.should.equal(1);
+    tags.length.should.equal(2);
   });
 
   it('should call prototype method `destroy` with given `options`', async () => {

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -8,6 +8,7 @@ export function recreateTables(repository) {
     .dropTableIfExists('Account')
     .dropTableIfExists('Comment')
     .dropTableIfExists('TagPost')
+    .dropTableIfExists('CommentMetadata')
     .dropTableIfExists('Post')
     .dropTableIfExists('Tag')
     .dropTableIfExists('Author')
@@ -26,6 +27,9 @@ export function recreateTables(repository) {
       table.increments('post_id').primary();
       table.integer('authorId').unsigned().references('Author.author_id');
     })
+    .createTable('CommentMetadata', table => {
+      table.increments('id').primary();
+    })
     .createTable('TagPost', table => {
       table.integer('tagId').unsigned().references('Tag.tag_id');
       table.integer('postId').unsigned().references('Post.post_id');
@@ -33,6 +37,7 @@ export function recreateTables(repository) {
     .createTable('Comment', table => {
       table.increments('comment_id').primary();
       table.integer('postId').unsigned().references('Post.post_id');
+      table.integer('metadata').unsigned().references('CommentMetadata.id');
     })
     .createTable('Commenter', table => {
       table.increments('commenter_id').primary();
@@ -49,6 +54,7 @@ export async function clearTables(repository) {
   await repository.knex('Commenter').del();
   await repository.knex('Comment').del();
   await repository.knex('TagPost').del();
+  await repository.knex('CommentMetadata').del();
   await repository.knex('Post').del();
   await repository.knex('Tag').del();
   await repository.knex('Author').del();
@@ -64,6 +70,7 @@ export function dropTables(repository) {
     .dropTable('Account')
     .dropTable('Commenter')
     .dropTable('Comment')
+    .dropTable('CommentMetadata')
     .dropTable('Post')
     .dropTable('Tag')
     .dropTable('Author');
@@ -84,14 +91,21 @@ export function fixtures(repository) {
     tableName: 'Commenter'
   });
 
+  const CommentMetadata = repository.Model.extend({
+    tableName: 'CommentMetadata'
+  });
+
   const Comment = repository.Model.extend({
     commenter() {
       return this.hasOne(Commenter, 'commentId');
     },
+    metadata() {
+      return this.belongsTo(CommentMetadata);
+    },
     idAttribute: 'comment_id',
     tableName: 'Comment'
   }, {
-    dependents: ['commenter']
+    dependents: ['commenter', 'metadata']
   });
 
   const Tag = repository.Model.extend({
@@ -130,5 +144,5 @@ export function fixtures(repository) {
     dependents: ['account', 'posts']
   });
 
-  return { Account, Author, Comment, Commenter, Post, Tag, TagPost };
+  return { Account, Author, Comment, CommentMetadata, Commenter, Post, Tag, TagPost };
 }


### PR DESCRIPTION
This PR fixes deleting dependents of the `belongsTo` relation, since the model that's being deleted is the one with the foreign key. 